### PR TITLE
fix: Mobile prose shouldn't have padding as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@
         <li><a href="#installation">Installation</a></li>
       </ul>
     </li>
-    <li><a href="#usage">Usage</a></li>
     <li><a href="#roadmap">Roadmap</a></li>
     <li><a href="#contributing">Contributing</a></li>
     <li><a href="#license">License</a></li>

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -87,7 +87,7 @@ onBeforeUnmount(() => {
     class="mx-auto flex flex-col-reverse lg:flex-row justify-center px-6 lg:px-0"
   >
     <article
-      class="prose prose-stone dark:prose-invert sm:max-w-[55ch] prose-pre:bg-gray-50 dark:prose-pre:bg-slate-800 dark:prose-pre:text-gray-50 prose-pre:border prose-pre:border-gray-200 dark:prose-pre:border-gray-700 prose-pre:border-solid prose-pre:rounded-lg prose-pre:text-slate-800 prose-headings:text-green-600 dark:prose-hr:border-gray-700 dark:prose-li:marker:text-gray-200 dark:prose-blockquote:border-gray-200 prose-headings:scroll-mt-24 dark:prose-tr:border-gray-500 dark:prose-thead:border-gray-400 prose-table:block lg:prose-table:table prose-table:overflow-x-scroll mx-auto lg:mx-0"
+      class="prose prose-stone dark:prose-invert sm:max-w-[55ch] prose-pre:bg-gray-50 dark:prose-pre:bg-slate-800 dark:prose-pre:text-gray-50 prose-pre:border prose-pre:border-gray-200 dark:prose-pre:border-gray-700 prose-pre:border-solid prose-pre:rounded-lg prose-pre:text-slate-800 prose-headings:text-green-600 dark:prose-hr:border-gray-700 dark:prose-li:marker:text-gray-200 dark:prose-blockquote:border-gray-200 prose-headings:scroll-mt-24 dark:prose-tr:border-gray-500 dark:prose-thead:border-gray-400 prose-table:block lg:prose-table:table prose-table:overflow-x-scroll sm:mx-auto lg:mx-0"
     >
       <ContentRenderer :value="(data as Record<string, any> | undefined)">
         <template #empty>


### PR DESCRIPTION
- Adding `mx-auto` to prose break the mobile view too